### PR TITLE
feat(Game): Add ability to initialize game background with game scale

### DIFF
--- a/src/client/src/Game/Game.hpp
+++ b/src/client/src/Game/Game.hpp
@@ -151,7 +151,7 @@ private:
      * @param mapData The JSON data representing the map.
      * @param window The SFML render window for the game.
      */
-    void initBackground(core::ecs::Registry& registry, nlohmann::json& mapData, sf::RenderWindow& window) const;
+    static void initBackground(core::ecs::Registry& registry, nlohmann::json& mapData, sf::RenderWindow& window, sf::Vector2f& gameScale);
 
     /**
      * @brief Initializes the window based on the configuration.

--- a/src/client/src/Game/Map.cpp
+++ b/src/client/src/Game/Map.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<sf::Texture> loadTextureOrRed(const std::string& filePath)
     return texture;
 }
 
-void Game::initBackground(core::ecs::Registry& registry, nlohmann::json& mapData, sf::RenderWindow& window) const
+void Game::initBackground(core::ecs::Registry& registry, nlohmann::json& mapData, sf::RenderWindow& window, sf::Vector2f& gameScale)
 {
     if (!mapData.contains("background")) {
         std::cerr << "Error: Missing essential map data fields." << std::endl;
@@ -96,8 +96,6 @@ void Game::parseMap(core::GameEngine& gameEngine, ConfigManager& config, const s
         return;
     }
 
-    initBackground(gameEngine.registry, mapData, window);
-
     std::unordered_map<int, sf::IntRect> tileRects;
     std::unordered_map<int, std::shared_ptr<sf::Texture>> tileTextures;
     int tileIndex = 0;
@@ -146,6 +144,8 @@ void Game::parseMap(core::GameEngine& gameEngine, ConfigManager& config, const s
     float scale = static_cast<float>(window.getSize().y) / mapHeight;
 
     gameScale = sf::Vector2f(scale, scale);
+
+    initBackground(gameEngine.registry, mapData, window, gameScale);
 
     for (const auto& tile : mapData["tiles"]) {
         if (!tile.contains("tileIndex") || !tile.contains("x") || !tile.contains("y") || !tile.contains("isDestructible")) {


### PR DESCRIPTION
This commit adds the ability to initialize the game The ` function in the` class now accepts angameScale parameter of type `sf This allows the the game.